### PR TITLE
Fix warnings

### DIFF
--- a/src/api/structs.rs
+++ b/src/api/structs.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize};
 
 
 #[derive(Deserialize, Debug, Clone)]
@@ -29,9 +29,9 @@ impl ToString for AreaForcast {
 }
 
 impl AreaForcast {
-    pub fn todays_weather_image(self) -> ForecastImage {
-        self.forecasts[0].image.clone()
-    }
+    // fn todays_weather_image(self) -> ForecastImage {
+    //     self.forecasts[0].image.clone()
+    // }
 
     pub fn title_with_weather_summary(&self) -> String {
         format!(
@@ -49,7 +49,7 @@ pub struct ForcastByDay {
     detail: WeatherDetail,
     temperature: Temperatures,
     chance_of_rain: ChanceOfRain,
-    image: ForecastImage,
+    // image: ForecastImage,
 }
 
 impl ToString for ForcastByDay {
@@ -132,8 +132,8 @@ impl ToString for ChanceOfRain {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all(deserialize = "camelCase", serialize = "snake_case"))]
 struct ForecastImage {
-    title: String,
-    url: String,
+    // title: String,
+    // url: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ mod tests {
             let webhook_username = "test_webhook_name";
             std::env::set_var("TERU2_WEBHOOK_USERNAME", webhook_username.to_string());
             assert_eq!(AppConfig::webhook_username(), webhook_username.to_string());
+            std::env::remove_var("TERU2_WEBHOOK_USERNAME");
         }
     }
     mod weather_forecast_api_url {
@@ -48,6 +49,7 @@ mod tests {
             let url = "https://weather.example.com";
             std::env::set_var("TERU2_WEATHER_FORECAST_API_URL", url.to_string());
             assert_eq!(AppConfig::weather_forecast_api_url(), url.to_string());
+            std::env::remove_var("TERU2_WEATHER_FORECAST_API_URL");
         }
     }
 
@@ -67,6 +69,7 @@ mod tests {
             let url = "https://discord.example.com";
             std::env::set_var("TERU2_DISCORD_WEBHOOK_URL", url.to_string());
             assert_eq!(AppConfig::webhook_url(), url.to_string());
+            std::env::remove_var("TERU2_DISCORD_WEBHOOK_URL");
         }
     }
 }


### PR DESCRIPTION
## Why?

Tests emit some warnings. It fails CI. It must be fixed.

## How?

* Fix warnings.
* Unused warnings are fixed by comment out. Because unused field/funs may be used soon.
* Fix fleaky tests