### PR TITLE
Build cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,3 +18,10 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
## Why?

Current CI has no cache. Build is too slow.

## How?

* Add cache(ref: https://zenn.dev/kt3k/articles/d557cc874961ab )
* [git-restore-mtime](https://github.com/MestreLion/git-tools/blob/master/git-restore-mtime) are not be used now


